### PR TITLE
Googlev3 zoom change fix

### DIFF
--- a/source/mxn.googlev3.core.js
+++ b/source/mxn.googlev3.core.js
@@ -46,9 +46,13 @@ Mapstraction: {
 			});
 
 			// deal with zoom change
-			google.maps.event.addListener(map, 'zoom_changed', function(){
-				me.changeZoom.fire();
+			google.maps.event.addlistener(map, 'zoom_changed', function(){
+				var idlelistener = google.maps.event.addlistener(map, 'idle', function() {
+					me.changezoom.fire();
+					google.maps.event.removelistener( idlelistener );
+				});
 			});
+
 			// deal with map movement
 			google.maps.event.addListener(map, 'dragend', function(){
 				me.moveendHandler(me);


### PR DESCRIPTION
The commit has details - this should make it possible to get the new viewport bounds in a zoomChanged event handler.
