### PR TITLE
Googlev3 closeBubble() refined

### DIFF
--- a/source/mxn.googlev3.core.js
+++ b/source/mxn.googlev3.core.js
@@ -454,8 +454,10 @@ Marker: {
 	},
 	
 	closeBubble: function() {
-		this.proprietary_infowindow.close();
-		this.closeInfoBubble.fire({'marker': this});
+		if (this.hasOwnProperty('proprietary_infowindow')) {
+			this.proprietary_infowindow.close();
+			this.closeInfoBubble.fire({'marker': this});
+		}
 	},
 
 	hide: function() {


### PR DESCRIPTION
ha i say on the commit log this one allow to call closeBubble() on a marker that haven't an opened bubble.
