### PR TITLE
Firefox 4 fix

### DIFF
--- a/source/mxn.js
+++ b/source/mxn.js
@@ -245,7 +245,9 @@ mxn.Invoker = function(aobj, asClassName, afnApiIdGetter){
 	this.go = function(sMethodName, args, oOptions){
 		
 		// make sure args is an array
-		args = Array.prototype.slice.apply(args);
+		if(args){
+			args = Array.prototype.slice.apply(args);
+		}
 		
 		if(typeof(oOptions) == 'undefined'){
 			oOptions = defOpts;


### PR DESCRIPTION
Firefox 4 throw an error "can't convert undefined to object" when using geocoder cause args is undefined.
