### PR TITLE
Made icon anchor offsets negative for openlayers.

### DIFF
--- a/source/mxn.openlayers.core.js
+++ b/source/mxn.openlayers.core.js
@@ -450,10 +450,9 @@ mxn.register('openlayers', {
 			}
 
 			if(this.iconAnchor) {
-				anchor = new OpenLayers.Pixel(this.iconAnchor[0], this.iconAnchor[1]);
+				anchor = new OpenLayers.Pixel(-this.iconAnchor[0], -this.iconAnchor[1]);
 			}
 			else {
-				// FIXME: hard-coding the anchor point
 				anchor = new OpenLayers.Pixel(-(size.w/2), -size.h);
 			}
 


### PR DESCRIPTION
Simple little fix to a FIXME: there was code to handle an iconAnchor array, but the offset direction was wrong. (The default if not specified was correct, probably why it wasn't caught earlier).
