### PR TITLE
Implementing getZoomLevelForBoundingBox for OpenLayers

### DIFF
--- a/source/mxn.openlayers.core.js
+++ b/source/mxn.openlayers.core.js
@@ -274,7 +274,21 @@ mxn.register('openlayers', {
 
 		getZoomLevelForBoundingBox: function( bbox ) {
 			var map = this.maps[this.api];
-			// throw 'Not implemented';
+
+			var sw = bbox.getSouthWest();
+			var ne = bbox.getNorthEast();
+
+			if(sw.lon > ne.lon) {
+				sw.lon -= 360;
+			}
+
+			var obounds = new OpenLayers.Bounds();
+			
+			obounds.extend(new mxn.LatLonPoint(sw.lat,sw.lon).toProprietary(this.api));
+			obounds.extend(new mxn.LatLonPoint(ne.lat,ne.lon).toProprietary(this.api));
+			
+			var zoom = map.getZoomForExtent(obounds);
+			
 			return zoom;
 		},
 


### PR DESCRIPTION
Implementing getZoomLevelForBoundingBox for OpenLayers.  Was just returning an undefined variable and throwing javascript errors before.
