### PR TITLE
endPan event fix for googleV3

### DIFF
--- a/source/mxn.googlev3.core.js
+++ b/source/mxn.googlev3.core.js
@@ -69,7 +69,7 @@ Mapstraction: {
 			});
 
 			// deal with map movement
-			google.maps.event.addListener(map, 'center_changed', function(){
+			google.maps.event.addListener(map, 'dragend', function(){
 				me.moveendHandler(me);
 				me.endPan.fire();
 			});


### PR DESCRIPTION
enddPan event shloud be fired on dragend google native event not on center_change (cause this one is fired multiple times during pan).
