### PR TITLE
fixes for Ovi getBounds and setBounds

### DIFF
--- a/source/mxn.core.js
+++ b/source/mxn.core.js
@@ -126,7 +126,7 @@ var Mapstraction = mxn.Mapstraction = function(element, api, debug) {
 		'changeZoom',
 		
 		/**
-		 * Marker is removed {marker: Marker}
+		 * Marker is added {marker: Marker}
 		 * @name mxn.Mapstraction#markerAdded
 		 * @event
 		 */


### PR DESCRIPTION
fixes to Ovi, particularly related to getBounds and setBounds. Unlike almost every other map provider it seems Ovi uses the north-west and south-east corners for bounds. I've thus also added getNorthWest and getSouthEast methods to mxn.BoundingBox as well.

Also I've incorperated the minor changes to mxn.ovi.core.js that I saw in other pull requests to ease merging.
