### PR TITLE
Added a way to control the googlev3 map background color by styling the map element

### DIFF
--- a/source/mxn.googlev3.core.js
+++ b/source/mxn.googlev3.core.js
@@ -16,6 +16,20 @@ Mapstraction: {
 				scrollwheel: false
 			};
 
+			// Background color can only be set at construction
+			// To provide some control, adopt any explicit element style
+			var backgroundColor = null;
+			if ( element.currentStyle ) {
+				backgroundColor = element.currentStyle['background-color'];
+			}
+			else if ( window.getComputedStyle ) {
+				backgroundColor = document.defaultView.getComputedStyle(element, null).getPropertyValue('background-color');
+			}
+			// Only set the background if a style has been explicitly set, ruling out the "transparent" default
+			if ( backgroundColor && 'transparent' !== backgroundColor ) {
+				myOptions.backgroundColor = backgroundColor;
+			}
+
 			// find controls
 			if (!this.addControlsArgs && loadoptions.addControlsArgs) {
 				this.addControlsArgs = loadoptions.addControlsArgs;


### PR DESCRIPTION
The Google API by itself ignores any background color style on the
map element and uses its own default grey background. This can be
overridden, but only as an option to the map constructor. That
restriction prevents us from using a Mapstration option to change
it.

This solution checks for an explicit style set on the map element.
The default "transparent" color is ignored - any other color found
is added to the constructor options. This is a nice low-impact solution
that doesn't impact other providers at all. I believe many others
behave this way already by default.

A different solution might be to add an optional third argument to
the Mapstraction constructor to allow overrides to default options.
Since it involves a constructor change and is API-specific, I decided
to propose the other option.
