### PR TITLE
Added Leaflet support and an example showing basic features

### DIFF
--- a/examples/leaflet.html
+++ b/examples/leaflet.html
@@ -37,7 +37,7 @@
       // add a polyline
       var pl = new mxn.Polyline([
           latlon,
-          latlon2,
+          latlon2
       ]);
       pl.color = '#00DD55';
       map.addPolyline(pl);

--- a/examples/leaflet.html
+++ b/examples/leaflet.html
@@ -1,0 +1,61 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>Mapstraction Examples - leaflet</title>
+<link href="http://d1qqc1e9kvmdh8.cloudfront.net/js/leaflet-0.2.1/leaflet.css" media="all" rel="stylesheet" type="text/css" />
+<!--[if lte IE 8]><link rel="stylesheet" href="http://d1qqc1e9kvmdh8.cloudfront.net/js/leaflet-0.2.1/leaflet.ie.css" /><![endif]-->
+<script src="http://d1qqc1e9kvmdh8.cloudfront.net/js/leaflet-0.2.1/leaflet.js" type="text/javascript"></script>
+<script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
+<script src="../source/mxn.js?(leaflet)" type="text/javascript"></script> 
+<style type="text/css">
+#mapdiv {
+  height: 400px;
+}
+</style> 
+<script type="text/javascript">
+//<![CDATA[
+  function initialize() {
+
+      // create mxn object
+      map = new mxn.Mapstraction('mapdiv', 'leaflet');
+      map.addTileLayer("http://{s}.google.com/vt/?hl=en&x={x}&y={y}&z={z}&s={s}", {
+         name: "Street",
+         attribution: "Map data: Copyright Google, 2011",
+         subdomains: ['mt0','mt1','mt2','mt3']
+      });
+
+      latlon = new mxn.LatLonPoint(41.84756115424155,-91.70015573501587)
+      latlon2 = new mxn.LatLonPoint(41.88756115424155,-91.20015573501587)
+
+      // put map on page
+      map.setCenterAndZoom(latlon, 12);
+
+      // add a marker
+      marker = new mxn.Marker(latlon);
+      map.addMarker(marker);
+      marker.addData({'infoBubble': 'This is a popup'})
+      marker.openBubble();
+
+      // add a polyline
+      var pl = new mxn.Polyline([
+          latlon,
+          latlon2,
+      ]);
+      pl.color = '#00DD55';
+      map.addPolyline(pl);
+
+      map.addSmallControls();
+  }
+//]]>
+</script> 
+</head>
+<body onload="initialize();">
+<center>
+<table border='1' width='50%'>
+<tr><td><div id="mapdiv"></div></td>
+</tr>
+</table>
+</center>
+</body>
+</html>
+
+

--- a/examples/leaflet.html
+++ b/examples/leaflet.html
@@ -16,12 +16,7 @@
 
       // create mxn object
       map = new mxn.Mapstraction('mapdiv', 'leaflet');
-      map.setOption({defaultLayer: false})
-      map.addTileLayer('http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png', {
-         name: "Cloudmade",
-         attribution: 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade'
-      });
-
+      map.setMapType(mxn.Mapstraction.SATELLITE);
       latlon = new mxn.LatLonPoint(41.84756115424155,-91.70015573501587)
       latlon2 = new mxn.LatLonPoint(41.88756115424155,-91.67015573501587)
 

--- a/examples/leaflet.html
+++ b/examples/leaflet.html
@@ -1,9 +1,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>Mapstraction Examples - leaflet</title>
-<link href="http://d1qqc1e9kvmdh8.cloudfront.net/js/leaflet-0.2.1/leaflet.css" media="all" rel="stylesheet" type="text/css" />
-<!--[if lte IE 8]><link rel="stylesheet" href="http://d1qqc1e9kvmdh8.cloudfront.net/js/leaflet-0.2.1/leaflet.ie.css" /><![endif]-->
-<script src="http://d1qqc1e9kvmdh8.cloudfront.net/js/leaflet-0.2.1/leaflet.js" type="text/javascript"></script>
+<link href="http://leaflet.cloudmade.com/dist/leaflet.css" media="all" rel="stylesheet" type="text/css" />
+<!--[if lte IE 8]><link rel="stylesheet" href="http://leaflet.cloudmade.com/dist/leaflet.ie.css" /><![endif]-->
+<script src="http://leaflet.cloudmade.com/dist/leaflet.js" type="text/javascript"></script>
 <script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
 <script src="../source/mxn.js?(leaflet)" type="text/javascript"></script> 
 <style type="text/css">

--- a/examples/leaflet.html
+++ b/examples/leaflet.html
@@ -4,7 +4,6 @@
 <link href="http://leaflet.cloudmade.com/dist/leaflet.css" media="all" rel="stylesheet" type="text/css" />
 <!--[if lte IE 8]><link rel="stylesheet" href="http://leaflet.cloudmade.com/dist/leaflet.ie.css" /><![endif]-->
 <script src="http://leaflet.cloudmade.com/dist/leaflet.js" type="text/javascript"></script>
-<script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
 <script src="../source/mxn.js?(leaflet)" type="text/javascript"></script> 
 <style type="text/css">
 #mapdiv {
@@ -17,14 +16,14 @@
 
       // create mxn object
       map = new mxn.Mapstraction('mapdiv', 'leaflet');
-      map.addTileLayer("http://{s}.google.com/vt/?hl=en&x={x}&y={y}&z={z}&s={s}", {
-         name: "Street",
-         attribution: "Map data: Copyright Google, 2011",
-         subdomains: ['mt0','mt1','mt2','mt3']
+      map.setOption({defaultLayer: false})
+      map.addTileLayer('http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png', {
+         name: "Cloudmade",
+         attribution: 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade'
       });
 
       latlon = new mxn.LatLonPoint(41.84756115424155,-91.70015573501587)
-      latlon2 = new mxn.LatLonPoint(41.88756115424155,-91.20015573501587)
+      latlon2 = new mxn.LatLonPoint(41.88756115424155,-91.67015573501587)
 
       // put map on page
       map.setCenterAndZoom(latlon, 12);

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -21,7 +21,10 @@ Mapstraction: {
     },
     
     applyOptions: function(){
-        return false;
+        if (this.options.scrollWheelZoom == false) {
+            this.maps[this.api].scrollWheelZoom.disable();
+        } 
+        return;
     },
 
     resizeTo: function(width, height){
@@ -130,15 +133,10 @@ Mapstraction: {
 
     getBounds: function () {
         var map = this.maps[this.api];
-        try {
-            var box = map.getBounds();
-            var ne, sw, nw, se;
-            sw = box.getSouthWest();
-            ne = box.getNorthEast();
-            return new mxn.BoundingBox(sw.lat, sw.lng, ne.lat, ne.lng);
-	} catch(e){
-            return;
-	}
+        var box = map.getBounds();
+        var sw = box.getSouthWest();
+        var ne = box.getNorthEast();
+        return new mxn.BoundingBox(sw.lat, sw.lng, ne.lat, ne.lng);
     },
 
     setBounds: function(bounds){

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -27,6 +27,7 @@ Mapstraction: {
             this.layers = {};
             this.features = [];
             this.maps[api] = map;
+            this.setMapType();
             this.loaded[api] = true;
         } else {
             alert(api + ' map script not imported');
@@ -34,7 +35,6 @@ Mapstraction: {
     },
     
     applyOptions: function(){
-        console.log(this.options);
         if (this.options.enableScrollWheelZoom == false) {
             this.maps[this.api].scrollWheelZoom.disable();
         } 
@@ -142,9 +142,32 @@ Mapstraction: {
     },
 
     setMapType: function(type) {
-        return false;
+        switch(type) {
+            case mxn.Mapstraction.ROAD:
+                this.addTileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png', {
+                    name: "Roads",
+                    attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">',
+                    subdomains: [1,2,3,4]
+                });
+                break;
+            case mxn.Mapstraction.SATELLITE:
+                this.addTileLayer('http://oatile{s}.mqcdn.com/naip/{z}/{x}/{y}.jpg', {
+                    name: "Satellite",
+                    attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">',
+                    subdomains: [1,2,3,4]
+                });
+                break;
+            case mxn.Mapstraction.HYBRID:
+                throw 'Not implemented';
+            default:
+                this.addTileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png', {
+                    name: "Roads",
+                    attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">',
+                    subdomains: [1,2,3,4]
+                });
+        }
     },
-
+//
     getMapType: function() {
         throw 'Not implemented';
     },

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -28,6 +28,7 @@ Mapstraction: {
             this.features = [];
             this.maps[api] = map;
             this.setMapType();
+            this.currentMapType = mxn.Mapstraction.ROAD;
             this.loaded[api] = true;
         } else {
             alert(api + ' map script not imported');
@@ -149,6 +150,7 @@ Mapstraction: {
                     attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">',
                     subdomains: [1,2,3,4]
                 });
+                this.currentMapType = mxn.Mapstraction.ROAD;
                 break;
             case mxn.Mapstraction.SATELLITE:
                 this.addTileLayer('http://oatile{s}.mqcdn.com/naip/{z}/{x}/{y}.jpg', {
@@ -156,6 +158,7 @@ Mapstraction: {
                     attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">',
                     subdomains: [1,2,3,4]
                 });
+                this.currentMapType = mxn.Mapstraction.SATELLITE;
                 break;
             case mxn.Mapstraction.HYBRID:
                 throw 'Not implemented';
@@ -165,11 +168,12 @@ Mapstraction: {
                     attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">',
                     subdomains: [1,2,3,4]
                 });
+                this.currentMapType = mxn.Mapstraction.ROAD;
         }
     },
-//
+
     getMapType: function() {
-        throw 'Not implemented';
+        return this.currentMapType;
     },
 
     getBounds: function () {

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -14,6 +14,16 @@ Mapstraction: {
             map.on("click", function(e) {
                 me.click.fire({'location': new mxn.LatLonPoint(e.latlng.lat, e.latlng.lng)});
             });
+            map.on("popupopen", function(e) {
+                if (e.popup._source.mxnMarker) {
+                  e.popup._source.mxnMarker.openInfoBubble.fire(e.popup._container);
+                }
+            });
+            map.on("popupclose", function(e) {
+                if (e.popup._source.mxnMarker) {
+                  e.popup._source.mxnMarker.closeInfoBubble.fire(e.popup._container);
+                }
+            });
             this.layers = {};
             this.features = [];
             this.maps[api] = map;
@@ -265,6 +275,7 @@ Marker: {
     openBubble: function() {
         var pin = this.proprietary_marker;
         if (this.infoBubble) {
+            pin.mxnMarker = this;
             pin.bindPopup(this.infoBubble);
             pin.openPopup();
         }

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -122,8 +122,12 @@ Mapstraction: {
         return map.getZoom();
     },
 
-    getZoomLevelForBoundingBox: function( bbox ) {
-        throw 'Not implemented';
+    getZoomLevelForBoundingBox: function(bbox) {
+        var map = this.maps[this.api];
+        var bounds = new L.LatLngBounds(
+            bbox.getSouthWest().toProprietary(this.api),
+            bbox.getNorthEast().toProprietary(this.api));
+        return map.getBoundsZoom(bounds);
     },
 
     setMapType: function(type) {

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -16,12 +16,12 @@ Mapstraction: {
             });
             map.on("popupopen", function(e) {
                 if (e.popup._source.mxnMarker) {
-                  e.popup._source.mxnMarker.openInfoBubble.fire(e.popup._container);
+                  e.popup._source.mxnMarker.openInfoBubble.fire({'bubbleContainer': e.popup._container});
                 }
             });
             map.on("popupclose", function(e) {
                 if (e.popup._source.mxnMarker) {
-                  e.popup._source.mxnMarker.closeInfoBubble.fire(e.popup._container);
+                  e.popup._source.mxnMarker.closeInfoBubble.fire({'bubbleContainer': e.popup._container});
                 }
             });
             this.layers = {};

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -1,0 +1,319 @@
+mxn.register('leaflet', {
+
+Mapstraction: {
+    
+    init: function(element, api) {
+        var me = this;
+        var map = new L.Map(element.id, {
+            zoomControl: false
+        });
+        this.layers = {};
+        this.features = [];
+        this.maps[api] = map;
+        this.loaded[api] = true;
+    },
+    
+    applyOptions: function(){
+        return false;
+    },
+
+    resizeTo: function(width, height){
+        this.currentElement.style.width = width;
+        this.currentElement.style.height = height;
+    },
+
+    addControls: function(args) {
+        var map = this.maps[this.api];
+        if (args.zoom) {
+            var zoom = new L.Control.Zoom();
+            map.addControl(zoom);
+        }
+        if (args.map_type) {
+            var layersControl = new L.Control.Layers(this.layers, this.features);
+            map.addControl(layersControl);
+        }
+    },
+
+    addSmallControls: function() {
+        this.addControls({zoom: true, map_type: true});
+    },
+
+    addLargeControls: function() {
+        throw 'Not implemented';
+    },
+
+    addMapTypeControls: function() {
+        throw 'Not implemented';
+    },
+
+    setCenterAndZoom: function(point, zoom) { 
+        var map = this.maps[this.api];
+        var pt = point.toProprietary(this.api);
+        map.setView(pt, zoom); 
+    },
+    
+    addMarker: function(marker, old) {
+        var map = this.maps[this.api];
+        var pin = marker.toProprietary(this.api);
+        map.addLayer(pin);
+        this.features.push(pin);
+        return pin;
+    },
+
+    removeMarker: function(marker) {
+        var map = this.maps[this.api];
+        map.removeLayer(marker.proprietary_marker);
+    },
+    
+    declutterMarkers: function(opts) {
+        throw 'Not implemented';
+    },
+
+    addPolyline: function(polyline, old) {
+        var map = this.maps[this.api];
+        polyline = polyline.toProprietary(this.api);
+        map.addLayer(polyline);
+        this.features.push(polyline);
+        return polyline;
+    },
+
+    removePolyline: function(polyline) {
+        var map = this.maps[this.api];
+        map.removeLayer(polyline.proprietary_polyline);
+    },
+
+    getCenter: function() {
+        var map = this.maps[this.api];
+        var pt = map.getCenter();
+        return new mxn.LatLonPoint(pt.lat, pt.lng);
+    },
+
+    setCenter: function(point, options) {
+        var map = this.maps[this.api];
+        var pt = point.toProprietary(this.api);
+        if(options && options.pan) { 
+            map.panTo(pt); 
+        }
+        else { 
+            map.setView(pt, map.getZoom(), true);
+        }
+    },
+
+    setZoom: function(zoom) {
+        var map = this.maps[this.api];
+        map.setZoom(zoom);
+    },
+    
+    getZoom: function() {
+        var map = this.maps[this.api];
+        return map.getZoom();
+    },
+
+    getZoomLevelForBoundingBox: function( bbox ) {
+        throw 'Not implemented';
+    },
+
+    setMapType: function(type) {
+        return false;
+    },
+
+    getMapType: function() {
+        throw 'Not implemented';
+    },
+
+    getBounds: function () {
+        var map = this.maps[this.api];
+        var ne, sw, nw, se;
+        var box = map.getBounds();
+        sw = box.getSouthWest();
+        ne = box.getNorthEast();
+        return new mxn.BoundingBox(sw.lat, sw.lng, ne.lat, ne.lng);
+    },
+
+    setBounds: function(bounds){
+        var map = this.maps[this.api];
+        var sw = bounds.getSouthWest().toProprietary(this.api);
+        var ne = bounds.getNorthEast().toProprietary(this.api);
+        var newBounds = new L.LatLngBounds(sw, ne);
+        map.fitBounds(newBounds); 
+    },
+
+    addImageOverlay: function(id, src, opacity, west, south, east, north) {
+        throw 'Not implemented';
+    },
+
+    setImagePosition: function(id, oContext) {
+        throw 'Not implemented';
+    },
+    
+    addOverlay: function(url, autoCenterAndZoom) {
+        throw 'Not implemented';
+    },
+
+    addTileLayer: function(tile_url, options) {
+        var layerName;
+        if (options && options.name) {
+            layerName = options.name;
+            delete options.name;
+        } else {
+            layerName = 'Tiles';
+        }
+        this.layers[layerName] = new L.TileLayer(tile_url, options || {});
+        var map = this.maps[this.api];
+        map.addLayer(this.layers[layerName]);
+    },
+
+    toggleTileLayer: function(tile_url) {
+        throw 'Not implemented';
+    },
+
+    getPixelRatio: function() {
+        throw 'Not implemented';
+    },
+    
+    mousePosition: function(element) {
+        throw 'Not implemented';
+    },
+
+    openBubble: function(point, content) {
+        var map = this.maps[this.api];
+        var newPoint = point.toProprietary(this.api);
+        var marker = new L.Marker(newPoint);
+        marker.bindPopup(content);
+        map.addLayer(marker);
+        marker.openPopup();
+    },
+
+    closeBubble: function() {
+        var map = this.maps[this.api];
+        map.closePopup();
+    }
+},
+
+LatLonPoint: {
+    
+    toProprietary: function() {
+        return new L.LatLng(this.lat,this.lon);
+    },
+
+    fromProprietary: function(point) {
+        this.lat = point.lat();
+        this.lon = point.lng();
+    }
+    
+},
+
+Marker: {
+    
+    toProprietary: function() {
+        var me = this;
+        var thisIcon = L.Icon;
+        if (me.iconUrl) {
+            thisIcon = thisIcon.extend({
+                iconUrl: me.iconUrl
+            });
+        }
+        if (me.iconSize) {
+            thisIcon = thisIcon.extend({
+                iconSize: new L.Point(me.iconSize[0], me.iconSize[1])
+            });
+        }
+        if (me.iconAnchor) {
+            thisIcon = thisIcon.extend({
+                iconAnchor: new L.Point(me.iconAnchor[0], me.iconAnchor[1])
+            });
+        }
+        if (me.iconShadowUrl) {
+            thisIcon = thisIcon.extend({
+                shadowUrl: me.iconShadowUrl
+            });
+        }
+        if (me.iconShadowSize) {
+            thisIcon = thisIcon.extend({
+                shadowSize: new L.Point(me.iconShadowSize[0], me.iconShadowSize[1])
+            });
+        }
+        var iconObj = new thisIcon();
+        var marker = new L.Marker(
+            this.location.toProprietary('leaflet'),
+            { icon: iconObj }
+        );
+        (function(me, marker) {
+            marker.on("click", function (e) {
+                me.click.fire();
+            });
+        })(me, marker);
+        return marker;
+    },
+
+    openBubble: function() {
+        var pin = this.proprietary_marker;
+        if (this.infoBubble) {
+            pin.bindPopup(this.infoBubble);
+            pin.openPopup();
+        }
+    },
+    
+    closeBubble: function() {
+        var pin = this.proprietary_marker;
+        pin.closePopup();
+    },
+
+    hide: function() {
+        var map = this.mapstraction.maps[this.api];
+        map.removeLayer(this.proprietary_marker);
+    },
+
+    show: function() {
+        var map = this.mapstraction.maps[this.api];
+        map.addLayer(this.proprietary_marker);
+    },
+    
+    isHidden: function() {
+        var map = this.mapstraction.maps[this.api];
+        if (map.hasLayer(this.proprietary_marker)) {
+            return false;
+        } else {
+            return true;
+        }
+    },
+
+    update: function() {
+        throw 'Not implemented';
+    }
+    
+},
+
+Polyline: {
+
+    toProprietary: function() {
+        var points = [];
+        for (var i = 0,  length = this.points.length ; i< length; i++){
+            points.push(this.points[i].toProprietary('leaflet'));
+        }
+        if (this.closed) {
+            return new L.Polygon(points);
+        } else {
+            return new L.Polyline(points);
+        }
+    },
+    
+    show: function() {
+        this.map.addLayer(this.proprietary_polyline);
+    },
+
+    hide: function() {
+        this.map.removeLayer(this.proprietary_polyline);
+    },
+    
+    isHidden: function() {
+        if (this.map.hasLayer(this.proprietary_polyline)) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}
+
+});
+

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -36,9 +36,11 @@ Mapstraction: {
     },
     
     applyOptions: function(){
-        if (this.options.enableScrollWheelZoom == false) {
+        if (this.options.enableScrollWheelZoom) {
+            this.maps[this.api].scrollWheelZoom.enable();
+        } else {
             this.maps[this.api].scrollWheelZoom.disable();
-        } 
+        }
         return;
     },
 

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -11,6 +11,9 @@ Mapstraction: {
             map.addEventListener('moveend', function(){
                 me.endPan.fire();
             }); 
+            map.on("click", function(e) {
+                me.click.fire({'location': new mxn.LatLonPoint(e.latlng.lat, e.latlng.lng)});
+            });
             this.layers = {};
             this.features = [];
             this.maps[api] = map;

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -3,14 +3,17 @@ mxn.register('leaflet', {
 Mapstraction: {
     
     init: function(element, api) {
-        var me = this;
-        var map = new L.Map(element.id, {
-            zoomControl: false
-        });
-        this.layers = {};
-        this.features = [];
-        this.maps[api] = map;
-        this.loaded[api] = true;
+        if (typeof(L) != 'undefined') {
+            var map = new L.Map(element.id, {
+                zoomControl: false
+            });
+            this.layers = {};
+            this.features = [];
+            this.maps[api] = map;
+            this.loaded[api] = true;
+        } else {
+            alert(api + ' map script not imported');
+        }
     },
     
     applyOptions: function(){

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -348,10 +348,18 @@ Polyline: {
         for (var i = 0,  length = this.points.length ; i< length; i++){
             points.push(this.points[i].toProprietary('leaflet'));
         }
+
+        var polyOptions = {
+            color: this.color || '#000000',
+            opacity: this.opacity || 1.0, 
+            weight: this.width || 3,
+            fillColor: this.fillColor || '#000000'
+        };
+
         if (this.closed) {
-            return new L.Polygon(points);
+            return new L.Polygon(points, polyOptions);
         } else {
-            return new L.Polyline(points);
+            return new L.Polyline(points, polyOptions);
         }
     },
     

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -34,7 +34,8 @@ Mapstraction: {
     },
     
     applyOptions: function(){
-        if (this.options.scrollWheelZoom == false) {
+        console.log(this.options);
+        if (this.options.enableScrollWheelZoom == false) {
             this.maps[this.api].scrollWheelZoom.disable();
         } 
         return;

--- a/source/mxn.leaflet.core.js
+++ b/source/mxn.leaflet.core.js
@@ -4,9 +4,13 @@ Mapstraction: {
     
     init: function(element, api) {
         if (typeof(L) != 'undefined') {
+            var me = this;
             var map = new L.Map(element.id, {
                 zoomControl: false
             });
+            map.addEventListener('moveend', function(){
+                me.endPan.fire();
+            }); 
             this.layers = {};
             this.features = [];
             this.maps[api] = map;
@@ -126,11 +130,15 @@ Mapstraction: {
 
     getBounds: function () {
         var map = this.maps[this.api];
-        var ne, sw, nw, se;
-        var box = map.getBounds();
-        sw = box.getSouthWest();
-        ne = box.getNorthEast();
-        return new mxn.BoundingBox(sw.lat, sw.lng, ne.lat, ne.lng);
+        try {
+            var box = map.getBounds();
+            var ne, sw, nw, se;
+            sw = box.getSouthWest();
+            ne = box.getNorthEast();
+            return new mxn.BoundingBox(sw.lat, sw.lng, ne.lat, ne.lng);
+	} catch(e){
+            return;
+	}
     },
 
     setBounds: function(bounds){


### PR DESCRIPTION
This is in response to the discussion in issue #97. In the patch you can find a simple Leaflet plug-in that provides support for tile layers, popups, custom icons, polylines and other basic functions. As discussed in the issue, it remains undecided what to do for the default tile layer. I'd like to notify @pmascari, @freyfogle and @nrabinowitz about this pull request.
