### PR TITLE
avoid map is not defined error, strage that jslint didn't point that on build

### DIFF
--- a/source/mxn.microsoft7.core.js
+++ b/source/mxn.microsoft7.core.js
@@ -359,7 +359,7 @@ Marker: {
 			Microsoft.Maps.Events.addHandler(mmarker, event_action, function() {
 				mmarker.mapstraction_marker.openBubble();
 			});
-			Microsoft.Maps.Events.addHandler(map, 'viewchange', function () {
+			Microsoft.Maps.Events.addHandler(this.map, 'viewchange', function () {
 				mmarker.mapstraction_marker.closeBubble();
 			});
 		}


### PR DESCRIPTION
small fix for microsoft7 core
