### PR TITLE
marker icons in openlayers

### DIFF
--- a/source/mxn.openlayers.core.js
+++ b/source/mxn.openlayers.core.js
@@ -515,8 +515,8 @@ mxn.register('openlayers', {
 			});
 
 			if(this.hoverIconUrl) {
-				icon = this.iconUrl || 'http://openlayers.org/dev/img/marker-gold.png';
-				hovericon = this.hoverIconUrl;
+				var icon = this.iconUrl || 'http://openlayers.org/dev/img/marker-gold.png';
+				var hovericon = this.hoverIconUrl;
 				marker.events.register("mouseover", marker, function(event) {
 					marker.setUrl(hovericon);
 				});


### PR DESCRIPTION
Marker icons were not correctly set after mouse events. If you have more than one marker on the map, each with a different icon, they would all wind up having the same icon after a mouse event fires on them. 
