### PR TITLE
bug fix in mxn core

### DIFF
--- a/source/mxn.core.js
+++ b/source/mxn.core.js
@@ -1503,7 +1503,6 @@ Marker.prototype.addData = function(options){
 					break;
 				case 'hover':
 					this.setHover(options.hover);
-					this.setHoverIcon(options.hoverIcon);
 					break;
 				case 'hoverIcon':
 					this.setHoverIcon(options.hoverIcon);


### PR DESCRIPTION
when hover property of icon was set to true, setHoverIcon was being called twice, the second call was setting the hover icon to undefined, thus overwriting the previously set value.
