### PR TITLE
Fixed color conversion in Microsoft v7 API

### DIFF
--- a/source/mxn.microsoft7.core.js
+++ b/source/mxn.microsoft7.core.js
@@ -410,18 +410,18 @@ Polyline: {
 			points.push(this.points[i].toProprietary(this.api));
 		}
 		
-		var strokeColor = Microsoft.Maps.Color.fromHex(this.color);
+		var strokeColor = Microsoft.Maps.Color.fromHex(this.color || '#000000');
 		strokeColor.a = this.opacity * 255;
-		var fillColor = Microsoft.Maps.Color.fromHex(this.fillColor);
+		var fillColor = Microsoft.Maps.Color.fromHex(this.fillColor || '#000000');
 		fillColor.a = this.fillOpacity * 255;
 		
 		var polyOptions = {
-			strokeColor: _strokeColor,
+			strokeColor: strokeColor,
 			strokeThickness: this.width
 		};
 
 		if (this.closed) {
-			polyOptions.fillColor = _fillColor;
+			polyOptions.fillColor = fillColor;
 			points.push(this.points[0].toProprietary(this.api));
 			return new Microsoft.Maps.Polygon(points, polyOptions);
 		}


### PR DESCRIPTION
There were a couple naming problems with the variables. Also added
reasonable defaults for the stroke and fill colors (i.e., black) - it
won't break anything because they're also fully transparent by default.
