### PR TITLE
getCenter() doesn't work in Bing Maps 7

### DIFF
--- a/source/mxn.microsoft7.core.js
+++ b/source/mxn.microsoft7.core.js
@@ -149,13 +149,10 @@ Mapstraction: {
 	},
 	
 	getCenter: function() {
-		var point;
 		var map = this.maps[this.api];
-		// Get the existing options.
-		var options = map.getOptions();
-		point = new mxn.LatLonPoint(options.center.latitude,options.center.longitude);
+		var center = map.getCenter();
 		
-		return point;
+		return new mxn.LatLonPoint(center.latitude, center.longitude);
 	},
 
 	setCenter: function(point, options) {


### PR DESCRIPTION
`getOptions()` does not return a `center` in the 7.0 API. Fixed by using
`getCenter()` instead.
