### PR TITLE
googlev3 Marker

### DIFF
--- a/source/mxn.googlev3.core.js
+++ b/source/mxn.googlev3.core.js
@@ -501,6 +501,7 @@ Marker: {
 		options.map = this.map;
 
 		var marker = new google.maps.Marker(options);
+		marker.mapstraction_marker = this;
 
 		if (this.infoBubble) {
 			var event_action = "click";


### PR DESCRIPTION
It's binding handlers to proprietary but had no reference back to the mxn marker in Marker.toProprietary() 
