### PR TITLE
Handle excessive use message in OpenLayers geocoder.

### DIFF
--- a/source/mxn.openlayers.geocoder.js
+++ b/source/mxn.openlayers.geocoder.js
@@ -13,6 +13,14 @@ Geocoder: {
 			address.address = [ address.street, address.locality, address.region, address.country ].join(', ');
 		}
 		
+		var handle_response = function(response){
+			if(response.status == 503){ // Service Temporarily Unavailable
+				me.error_callback("OpenLayers geocoding is temporarily unavailable (were you blocked for excessive use?)");
+			}else{
+				me.geocode_callback(JSON.parse(response.responseText), response.status);
+			}
+		};
+		
 		if (address.hasOwnProperty('lat') && address.hasOwnProperty('lon')) {
 			var latlon = address.toProprietary(this.api);
 			OpenLayers.Request.GET({
@@ -23,7 +31,7 @@ Geocoder: {
 					'addressdetails': 1,
 					'format': 'json'
 				},
-				callback: function(request) { me.geocode_callback(JSON.parse(request.responseText), request.status); }
+				callback: handle_response
 			});
 		} else {
 			OpenLayers.Request.GET({
@@ -33,7 +41,7 @@ Geocoder: {
 					'addressdetails': 1,
 					'format': 'json'
 				},
-				callback: function(request) { me.geocode_callback(JSON.parse(request.responseText), request.status); }
+				callback: handle_response
 			});
 		}
 	},


### PR DESCRIPTION
I foolishly started calling the OpenLayers geocoder too quickly and was temporarily blocked. This exposed an error in the mxn openlayers geocoder api. OpenLayers responds to excessive use with a 503 status and an HTML page explaining the problem. The mxn api was trying to parse the HTML as JSON and throwing an uncaught error. I changed it to detect the 503 prior to JSON decoding and try to provide a helpful error message.

Todo: It might make sense, instead of my generic message, to actually parse the HTML response and have a different message for excessive use than for other 503 situations. But this is a lot better than nothing.

There's also a bug request to switch to the mapquest API for openlayers, and I don't know if that would obviate this whole thing ...
