### PR TITLE
fix openlayers geocoder examples

### DIFF
--- a/examples/openlayers_geocoder.html
+++ b/examples/openlayers_geocoder.html
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>Mapstraction Examples - OpenLayers Geocoder</title>
-<script src="http://openlayers.org/api/OpenLayers.js"></script>
+<script src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
 <script src="../source/mxn.js?(openlayers,[geocoder])" type="text/javascript"></script>
 <style type="text/css">
 

--- a/examples/openlayers_reverse_geocoder.html
+++ b/examples/openlayers_reverse_geocoder.html
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>Mapstraction Examples - OpenLayers Reverse Gecoder</title>
-<script src="http://openlayers.org/api/OpenLayers.js"></script>
+<script src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
 <script src="../source/mxn.js?(openlayers,[geocoder])" type="text/javascript"></script>
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js" type="text/javascript"></script>
 <style type="text/css">


### PR DESCRIPTION
use opnelayers 2.11 cause 2.12 break OpenLayers.Request.GET on diffrent domain (same origin policy)
