### PR TITLE
Fixes for Bing Maps provider (microsoft7)

### DIFF
--- a/source/mxn.microsoft7.core.js
+++ b/source/mxn.microsoft7.core.js
@@ -364,11 +364,11 @@ Marker: {
 	},
 
 	openBubble: function() {		
-		var infowindow = new Microsoft.Maps.InfoBox({
+		var infowindow = new Microsoft.Maps.Infobox({
 			description: this.infoBubble
 		});
 		
-		this.events.openInfoBubble.fire({'marker': this});
+		this.openInfoBubble.fire({'marker': this});
 		this.map.entities.push(infowindow);
 		infowindow.setOptions({visible: true});
 		this.proprietary_infowindow = infowindow; // Save so we can close it later

--- a/source/mxn.microsoft7.geocoder.js
+++ b/source/mxn.microsoft7.geocoder.js
@@ -16,7 +16,7 @@ mxn.register('microsoft7', {
 				}
 				// query is an address object
 				else {
-					_address = [ query.street, query.locality, query.region, query.country ].join(', ');
+					_address = [ query.street, query.locality, query.region, query.country ].join(',');
 				}
 			}
 			// query is an address string

--- a/source/mxn.microsoft7.geocoder.js
+++ b/source/mxn.microsoft7.geocoder.js
@@ -37,14 +37,14 @@ mxn.register('microsoft7', {
 			}
 			else {
 				var topResult = results.resourceSets[0].resources[0];
-				var return_location = {
+				var return_location = topResult ? {
 					street: topResult.address.addressLine,
 					locality: topResult.address.locality,
 					postcode: topResult.address.postalCode,
 					region: topResult.address.adminDistrict,
 					country: topResult.address.countryRegion,
 					point: new mxn.LatLonPoint(topResult.point.coordinates[0], topResult.point.coordinates[1])			
-				};
+				} : null;
 				this.callback(return_location);
 			}
 		}


### PR DESCRIPTION
1) Bing Maps Locations REST endpoint rejects queries that end in whitespace

When geocoding using Bing Maps provider, for cases where country field is empty, the resulting _address string ends in whitespace. For unknown reasons Bing Maps Locations REST web service (http://msdn.microsoft.com/en-us/library/ff701711.aspx) doesn't parse that well and returns 404 so geocode_callback is never called.

Here's an example (replace BingMapsKey with your key):
http://dev.virtualearth.net/REST/v1/Locations/1%20Microsoft%20Way,%20Redmond,%20,%20,%20?output=json&jsonp=jsonp_callback_context.geocode_callback&key=BingMapsKey

Ideally line 24 should also be fixed something like _address = query.trim();

2) in mxn.microsoft7.core.js there were some syntax error typos in Marker.openBubble(). Specifically Infobox is misspelled (http://msdn.microsoft.com/en-us/library/gg675208) and openInfoBubble() doesn't hang off an events object. 

3) Some geocode queries result in an empty results.resourceSets[0].resources array which would cause null dereferencing exception.

Here's an example (replace BingMapsKey with your key):
http://dev.virtualearth.net/REST/v1/Locations/not%20an%20address%20random?output=json&jsonp=jsonp_callback_context.geocode_callback&key=BingMapsKey
