### PR TITLE
Making it easier to use the minified versions

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -20,9 +20,11 @@
 		</tstamp>
 		<property name="build.ver" value="${build.major}.${build.minor}.${build.number}"/>
 		<property name="build.dir" location="${build.base}/${build.ver}"/>
+		<property name="min.dir" location="${build.dir}/min"/>
 		
 		<!-- make our build directory -->
 		<mkdir dir="${build.dir}"/>
+		<mkdir dir="${min.dir}"/>
 		
 		<!-- copy our sources in -->
 		<echo>--- COPY SOURCES ---</echo>
@@ -68,7 +70,7 @@
 			</path>
 			<sequential>
 				<propertyregex override="yes" property="minfile" input="@{file}" regexp=".*[\/\\]([a-z0-9\.]+)\.js" replace="\1-min.js"/>
-				<java jar="tools/yui-compressor/yuicompressor-2.4.2.jar" args="-o ${build.dir}/${minfile} @{file}" fork="true" failonerror="true"/>
+				<java jar="tools/yui-compressor/yuicompressor-2.4.2.jar" args="-o ${min.dir}/${minfile} @{file}" fork="true" failonerror="true"/>
 			</sequential>
 		</for>		
 		


### PR DESCRIPTION
Minified files are written into build/min, without the license part to keep them small. Maybe a README or LICENSE file should be created there? You decide ;)
