### PR TITLE
Ignore additional URL encoded parameters when including mxn.js into a page

### DIFF
--- a/source/mxn.js
+++ b/source/mxn.js
@@ -18,7 +18,7 @@
 
 	// Determine which scripts we need to load	
 	for (var i = 0; i < scripts.length; i++) {
-		var match = scripts[i].src.replace(/%20/g , '').match(/^(.*?)mxn\.js(\?\(\[?(.*?)\]?\))?$/);
+		var match = scripts[i].src.replace(/%20/g , '').match(/^(.*?)mxn\.js(\?\(\[?(.*?)\]?\))?(.*)$/);
 		if (match !== null) {
 			scriptBase = match[1];
 			if (match[3]) {


### PR DESCRIPTION
WordPress uses the wp_register_script and/or wp_include_script API call to marshall included JavaScript files. Both these API calls append the current WordPress version number, as &ver=nnnn pr &#38;ver=nnn, to the scripts source URL. This fix causes MXN to ignore these additional parameters.
