### PR TITLE
Fixed microsoft7 example, and implemented removeallmarkers in microsoft7

### DIFF
--- a/examples/microsoft7.html
+++ b/examples/microsoft7.html
@@ -8,6 +8,7 @@
 	
 	#mapdiv {
 		height: 400px;
+		position: relative;
 	}
 
 </style> 

--- a/examples/microsoft7.html
+++ b/examples/microsoft7.html
@@ -60,8 +60,8 @@
 
 		// add a marker
 		var marker = new mxn.Marker(latlon);
-		mapstraction.addMarker(marker,true);
-		
+		mapstraction.addMarker(marker);
+
 	}
 
 	function user_submit() {

--- a/source/mxn.core.js
+++ b/source/mxn.core.js
@@ -625,12 +625,18 @@ Mapstraction.prototype.removeMarker = function(marker) {
 
 /**
  * removeAllMarkers removes all the Markers on a map
+ * If there is no implementation of removeAllMarkers then do them one at a time 
  */
 Mapstraction.prototype.removeAllMarkers = function() {
-	var current_marker;
-	while(this.markers.length > 0) {
-		current_marker = this.markers.pop();
-		this.invoker.go('removeMarker', [current_marker]);
+	try {
+		this.invoker.go('removeAllMarkers', arguments);	
+		this.markers.length = 0;
+	} catch (x) {
+		var current_marker;
+		while(this.markers.length > 0) {
+			current_marker = this.markers.pop();
+			this.invoker.go('removeMarker', [current_marker]);
+		}
 	}
 };
 

--- a/source/mxn.microsoft7.core.js
+++ b/source/mxn.microsoft7.core.js
@@ -130,7 +130,12 @@ Mapstraction: {
 		
 		// TODO: Add provider code
 	},
-
+/*
+	removeAllMarkers: function () {
+		var map = this.maps[this.api];
+		map.entities.clear();
+	},
+	*/
 	addPolyline: function(polyline, old) {
 		var map = this.maps[this.api];
 		var pl = polyline.toProprietary(this.api);

--- a/source/mxn.microsoft7.core.js
+++ b/source/mxn.microsoft7.core.js
@@ -130,12 +130,12 @@ Mapstraction: {
 		
 		// TODO: Add provider code
 	},
-/*
+
 	removeAllMarkers: function () {
 		var map = this.maps[this.api];
 		map.entities.clear();
 	},
-	*/
+	
 	addPolyline: function(polyline, old) {
 		var map = this.maps[this.api];
 		var pl = polyline.toProprietary(this.api);


### PR DESCRIPTION
Whats the deal with removeallmarkers, should this be implemented in all providers? 
If so how do I get it to call this if implemented and fallback to calling removemarker singly when its not there. I had a try with fallback, but can't see any other example to follow - are there any?
