### PR TITLE
Revert "Merge pull request #151 from brunob/hotfixes"

### DIFF
--- a/examples/openlayers_geocoder.html
+++ b/examples/openlayers_geocoder.html
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>Mapstraction Examples - OpenLayers Geocoder</title>
-<script src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
+<script src="http://openlayers.org/api/OpenLayers.js"></script>
 <script src="../source/mxn.js?(openlayers,[geocoder])" type="text/javascript"></script>
 <style type="text/css">
 

--- a/examples/openlayers_reverse_geocoder.html
+++ b/examples/openlayers_reverse_geocoder.html
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>Mapstraction Examples - OpenLayers Reverse Gecoder</title>
-<script src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
+<script src="http://openlayers.org/api/OpenLayers.js"></script>
 <script src="../source/mxn.js?(openlayers,[geocoder])" type="text/javascript"></script>
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js" type="text/javascript"></script>
 <style type="text/css">


### PR DESCRIPTION
CORS issues  got fixed on the server (Nominatim) side.

See
https://github.com/twain47/Nominatim/commit/0dd10c3fff9896ca23b884a7ec7a97002065d083
https://github.com/twain47/Nominatim/commit/490190b8739241b84ead87ed47f8a3c65553fe10

http://openlayers.org/api/OpenLayers.js works perfectly now, so no reason to use a fixed old version in the geocoder examples.

This reverts https://github.com/mapstraction/mxn/pull/151
