### PR TITLE
Implement a jQuery+Nominatim geocoder based on the OpenLayers+Nominatim geocoder.

### DIFF
--- a/source/mxn.jquery.geocoder.js
+++ b/source/mxn.jquery.geocoder.js
@@ -1,0 +1,138 @@
+/*
+ * This geocoder is based on the OpenLayers geocoder.
+ * It should be kept in sync and has exactly the same code,
+ * but uses JQuery.ajax() instead of OpenLayers.Request.GET to load data from Nominatim.
+ */
+mxn.register('jquery', {
+
+Geocoder: {
+	init: function() {
+	},
+
+	geocode: function(address, rowlimit) {
+		var me = this;
+		me.row_limit = rowlimit || 1; //default to one result
+
+		var url = 'http://nominatim.openstreetmap.org/';
+		var params = {
+			'addressdetails': 1,
+			'format': 'json'
+		};
+
+		if (address.hasOwnProperty('lat') && address.hasOwnProperty('lon')) {
+			url += 'reverse';
+			params.lat = address.lat;
+			params.lon = address.lon;
+		} else {
+			url += 'search';
+			if (!address.hasOwnProperty('address') || address.address === null || address.address === '') {
+				address.address = [ address.street, address.locality, address.region, address.country ].join(', ');
+			}
+			if (address.hasOwnProperty('address')) {
+				params.q = address.address;
+			}
+			else {
+				params.q = address;
+			}
+			params.limit = me.row_limit;
+		}
+
+		jQuery.ajax({
+			url: url,
+			data: params,
+			dataType: 'json',
+			success: function(results) {
+				me.geocode_callback(results, me.row_limit);
+			},
+			error: function(response) {
+				if (response.status == 503) { // Service Temporarily Unavailable
+					me.error_callback("Nominatim is temporarily unavailable (were you blocked for excessive use?)");
+				} else {
+					me.error_callback(response.statusText);
+				}
+			}
+		});
+	},
+
+	geocode_callback: function(results, rowlimit) {
+		if (results instanceof Array) {
+			if (!results.length) {
+				this.error_callback("Nominatim didn't recognize this address.");
+				return;
+			}
+		}
+		else {
+			results = [results];
+		}
+
+		var place;
+		var places = [];
+
+		for (i=0; i<results.length; i++) {
+			place = results[i];
+			var return_location = {};
+			return_location.street = '';
+			return_location.locality = '';
+			return_location.postcode = '';
+			return_location.region = '';
+			return_location.country = '';
+			var street_components = [];
+
+			if (place.address.country) {
+				return_location.country = place.address.country;
+			}
+			if (place.address.state_district) {
+				return_location.region = place.address.state_district;
+			}
+			else if (place.address.state) {
+				return_location.region = place.address.state;
+			}
+			if (place.address.city) {
+				return_location.locality = place.address.city;
+			}
+			else if (place.address.town) {
+				return_location.locality = place.address.town;
+			}
+			else if (place.address.village) {
+				return_location.locality = place.address.village;
+			}
+			else if (place.address.hamlet) {
+				return_location.locality = place.address.hamlet;
+			}
+
+			if (!return_location.locality && place.address.county) {
+				return_location.locality = place.address.county;
+			}
+
+			if (place.address.postcode) {
+				return_location.postcode = place.address.postcode;
+			}
+			if (place.address.road) {
+				street_components.push(place.address.road);
+			}
+			if (place.address.house_number) {
+				street_components.unshift(place.address.house_number);
+			}
+
+			if (return_location.street === '' && street_components.length > 0) {
+				return_location.street = street_components.join(' ');
+			}
+
+			return_location.point = new mxn.LatLonPoint(parseFloat(place.lat), parseFloat(place.lon));
+
+			places.push(return_location);
+		}
+
+		if (rowlimit <= 1) {
+			this.callback(places[0]);
+		}
+		else {
+			if (places.length > rowlimit) {
+				places.length = rowlimit;
+			}
+			this.callback(places);
+		}
+	}
+}
+
+});


### PR DESCRIPTION
The only difference is in the method used to load data from Nominatim.
OpenLayers geocoder uses OpenLayers.Request.GET(), jQuery geocoder uses jQuery.ajax().

Actually, I'm not sure if this is needed or useful, but the usecase I'm thinking about is if one is already using jQuery while using some other map provider (that does not have a geocoder?). There should be no need to load OpenLayers library in such situations.

I'm not sure if 'jquery' is a proper name for this geocoder (it's actually jQuery.ajax() + Nominatim), but I named it similar to the 'openlayers' geocoder (which is actually OpenLayers.Request.GET() + Nominatim).

Also, this file uses CRLF line terminators, like mxn.openlayers.geocoder.js. There seems to be a mix in the repo, but I decided not to touch mxn.openlayers.geocoder.js and keep mxn.jquery.geocoder.js also CRLF to ease diffing between them (yes, I know about the --ignore-all-space flag).

If you want LF line terminators for all new files, you can change that.
