### PR TITLE
Use JSON.parse instead of eval() when possible.

### DIFF
--- a/source/mxn.core.js
+++ b/source/mxn.core.js
@@ -945,7 +945,11 @@ Mapstraction.prototype.setImagePosition = function(id) {
 Mapstraction.prototype.addJSON = function(json) {
 	var features;
 	if (typeof(json) == "string") {
-		features = eval('(' + json + ')');
+		if (window.JSON && window.JSON.parse) {
+			features = window.JSON.parse(json);
+		} else {
+			features = eval('(' + json + ')');
+		}
 	} else {
 		features = json;
 	}


### PR DESCRIPTION
JSON.parse is available in all major browsers since IE8 (which is near-dead already): http://caniuse.com/json

It's much better than an eval, it's more secure and it works nicely under CSP restrictions (if unsafe-eval isn't allowed).

This is the first little step for working with disabled unsafe-eval.
Also, all instances of «new Function(» should be removed, but this commit is just about JSON.parse.

When JSON.parse is unavailable, fallback to eval().
