### PR TITLE
Change removed navigationControl to zoomControl and panControl.

### DIFF
--- a/source/mxn.googlev3.core.js
+++ b/source/mxn.googlev3.core.js
@@ -11,8 +11,8 @@ Mapstraction: {
 				mapTypeId: google.maps.MapTypeId.ROADMAP,
 				mapTypeControl: false,
 				mapTypeControlOptions: null,
-				navigationControl: false,
-				navigationControlOptions: null,
+				zoomControl: false,
+				zoomControlOptions: null,
 				scrollwheel: false,
 				disableDoubleClickZoom: true
 			};
@@ -37,12 +37,12 @@ Mapstraction: {
 			}
 			if (this.addControlsArgs) {
 				if (this.addControlsArgs.zoom) {
-					myOptions.navigationControl = true;
+					myOptions.zoomControl = true;
 					if (this.addControlsArgs.zoom == 'small') {
-						myOptions.navigationControlOptions = {style: google.maps.NavigationControlStyle.SMALL};
+						myOptions.zoomControlOptions = {style: google.maps.ZoomControlStyle.SMALL};
 					}
 					if (this.addControlsArgs.zoom == 'large') {
-						myOptions.navigationControlOptions = {style: google.maps.NavigationControlStyle.ZOOM_PAN};
+						myOptions.zoomControlOptions = {style: google.maps.ZoomControlStyle.LARGE};
 					}
 				}
 				if (this.addControlsArgs.map_type) {
@@ -143,13 +143,17 @@ Mapstraction: {
 		var myOptions;
 		// remove old controls
 
-		// Google has a combined zoom and pan control.
-		if (args.zoom || args.pan) {
+		if (args.pan) {
+			map.setOptions({ panControl: true });
+		}
+		if (args.zoom) {
+			myOptions = { zoomControl: true };
 			if (args.zoom == 'large'){ 
-				this.addLargeControls();
+				myOptions.zoomControlOptions = {style: google.maps.ZoomControlStyle.LARGE};
 			} else { 
-				this.addSmallControls();
+				myOptions.zoomControlOptions = {style: google.maps.ZoomControlStyle.SMALL};
 			}
+			map.setOptions(myOptions);
 		}
 		if (args.scale){
 			myOptions = {
@@ -175,8 +179,8 @@ Mapstraction: {
 	addSmallControls: function() {
 		var map = this.maps[this.api];
 		var myOptions = {
-			navigationControl: true,
-			navigationControlOptions: {style: google.maps.NavigationControlStyle.SMALL}
+			zoomControl: true,
+			zoomControlOptions: {style: google.maps.ZoomControlStyle.SMALL}
 		};
 		map.setOptions(myOptions);
 
@@ -188,8 +192,9 @@ Mapstraction: {
 	addLargeControls: function() {
 		var map = this.maps[this.api];
 		var myOptions = {
-			navigationControl: true,
-			navigationControlOptions: {style:google.maps.NavigationControlStyle.DEFAULT}
+			zoomControl: true,
+			zoomControlOptions: {style:google.maps.ZoomControlStyle.LARGE},
+			panControl: true
 		};
 		map.setOptions(myOptions);
 		this.addControlsArgs.pan = true;

--- a/source/mxn.googlev3.core.js
+++ b/source/mxn.googlev3.core.js
@@ -43,6 +43,7 @@ Mapstraction: {
 					}
 					if (this.addControlsArgs.zoom == 'large') {
 						myOptions.zoomControlOptions = {style: google.maps.ZoomControlStyle.LARGE};
+						myOptions.panControl = true;
 					}
 				}
 				if (this.addControlsArgs.map_type) {


### PR DESCRIPTION
This fixes issue #253, and should repair the broken methods `addControls()`, `addLargeControls()`, and `addSmallControls()`, as well as the global loadoptions.addControlArgs initialization variable for zoom and pan controls.

In `tests/core.html`, action 12 "Add Controls" should work again.
