### PR TITLE
Remove handler on each step of view change

### DIFF
--- a/source/mxn.microsoft7.core.js
+++ b/source/mxn.microsoft7.core.js
@@ -48,9 +48,6 @@ Mapstraction: {
 		Microsoft.Maps.Events.addHandler(this.maps[api], 'viewchangeend', function(event){
 			me.endPan.fire();
 		});
-		Microsoft.Maps.Events.addHandler(this.maps[api], 'viewchange', function(event){
-			me.endPan.fire();
-		});
 	},
 	
 	applyOptions: function(){


### PR DESCRIPTION
Viewchange event is called on each frame on change on map. It will be
called multiple time for a single drag'n'drop user action, which is not
the intent of endPan mxn event.
