### PR TITLE
Fixes for yandex2.core Placemarks.

### DIFF
--- a/source/mxn.yandex2.core.js
+++ b/source/mxn.yandex2.core.js
@@ -422,42 +422,43 @@ LatLonPoint: {
 Marker: {
 	
 	toProprietary: function() {
+		var properties = {
+		};
+
 		var options = {
-			hideIcon: false,
 			draggable: this.draggable
 		};
-		
+
+		if (this.labelText) {
+			properties.iconContent = this.labelText;
+			if (properties.iconContent.length > 1) {
+				options.preset = 'twirl#blueStretchyIcon';
+			}
+		}
+
 		if (this.iconUrl) {
-			options.iconImageHref = this.iconUrl;
-		}	
+			if (this.iconUrl[0] === '#') {
+				// See http://api.yandex.ru/maps/doc/jsapi/2.x/ref/reference/option.presetStorage.xml for all the predefined icons
+				options.preset = 'twirl' + this.iconUrl;
+			} else {
+				options.iconImageHref = this.iconUrl;
+			}
+		}
+		if (this.iconSize) {
+			options.iconImageSize = [this.iconSize[0], this.iconSize[1]];
+		}
 		if (this.iconShadowUrl) {
 			options.iconShadowImageHref = this.iconShadowUrl;
 		}
 		if (this.iconShadowSize) {
 			options.iconShadowImageSize = [this.iconShadowSize[0], this.iconShadowSize[1]];
-		}			
-
+		}
 		if (this.iconAnchor) {
 			options.iconOffset = [this.iconAnchor[0], this.iconAnchor[1]];
 		}
-	
-		if (this.labelText) {
-			options.iconContent = this.labelText; 
-		}
+
+		var ymarker = new ymaps.Placemark(this.location.toProprietary('yandex2'), properties, options);
 		
-		var ymarker = new ymaps.Placemark(this.location.toProprietary('yandex2'), options);
-		
-		if (this.iconUrl) {
-			var postoptions = {
-				iconImageHref: this.iconUrl
-			};
-			
-			if (this.iconSize) {
-				postoptions.iconImageSize = [this.iconSize[0], this.iconSize[1]];
-			}
-			
-			ymarker.options.set(postoptions);
-		}		
 		
 		if (this.hoverIconUrl) {
 			var me = this;
@@ -481,7 +482,9 @@ Marker: {
 
 	openBubble: function() {
 		this.proprietary_marker.properties.set({
-			balloonContent: this.infoBubble
+			balloonContentHeader: this.labelText || '',
+			//balloonContentFooter: 'footer',
+			balloonContentBody: this.infoBubble,
 		});
 		
 		this.proprietary_marker.balloon.open();


### PR DESCRIPTION
Proper names for `properties` and `options`, put everything where it belongs.
No need for `postoptions` now, pass both `properties` and `options` in ymaps.Placemark constructor.

Support predefined icons from http://api.yandex.ru/maps/doc/jsapi/2.x/ref/reference/option.presetStorage.xml.

Use wide icon by default to fit the label if the label (`this.labelText`) is longer than one symbol.

Add `this.labelText` as the balloon header to keep it visible when the ballon is opened.

Remove `hideIcon: false,` it never worked.
